### PR TITLE
Store backstop results in artifacts directory

### DIFF
--- a/bin/drupal-auto-update.sh
+++ b/bin/drupal-auto-update.sh
@@ -91,6 +91,9 @@ else
     VISUAL_REGRESSION_RESULTS=$(backstop test || echo 'true')
 
     echo "${VISUAL_REGRESSION_RESULTS}"
+    
+    echo -e "\nSync test results to artifacts directory..."
+    rsync -rlvz backstop_data $CIRCLE_ARTIFACTS
 
     if [[ ${VISUAL_REGRESSION_RESULTS} == *"Mismatch errors found"* ]]
     then


### PR DESCRIPTION
Putting the backstop test results in the `CIRCLE_ARTIFACTS` directory allows for them to be accessed through the Circle UI.

![screen shot 2018-01-12 at 9 38 16 am](https://user-images.githubusercontent.com/211029/34882517-6fefa4e4-f77c-11e7-9b7f-e7687fcf756d.png)

Here is an example report: https://15-94147890-gh.circle-artifacts.com/0/tmp/circle-artifacts.qCfIs6Y/backstop_data/html_report/index.html

This change allows results to be viewed without the Slack dependency.
